### PR TITLE
Enable local cache in runner

### DIFF
--- a/register_and_run.sh
+++ b/register_and_run.sh
@@ -1,5 +1,11 @@
 #!/bin/bash -ex
 
+error() { echo "$@" >&2 ; exit 1 ; }
+
+# Check for some required environment variables
+[[ -n "${GITLABURL}" ]] || error "GITLABURL environment variable must be set"
+[[ -n "${RUNNERTOKEN}" ]] || error "RUNNERTOKEN environment variable must be set"
+
 # Set some sensible default values
 : "${EXECUTOR:=docker}"
 : "${DOCKERIMAGE:=alpine:latest}"

--- a/register_and_run.sh
+++ b/register_and_run.sh
@@ -1,15 +1,22 @@
 #!/bin/bash -ex
 
+# Set some sensible default values
+: "${EXECUTOR:=docker}"
+: "${DOCKERIMAGE:=alpine:latest}"
+: "${RUNNERNAME:=gitlab runner}"
+: "${TAGLIST:=docker,auto}"
+
 echo "GITLABURL: ${GITLABURL}"
 echo "RUNNERTOKEN: ${RUNNERTOKEN}"
-echo "EXECUTOR: ${EXECUTOR:-docker}"
-echo "DOCKERIMAGE: ${DOCKERIMAGE:-alpine:latest}"
-echo "RUNNERNAME: ${RUNNERNAME:-gitlab runner}"
-echo "TAGLIST: ${TAGLIST:-docker,auto}"
+echo "EXECUTOR: ${EXECUTOR}"
+echo "DOCKERIMAGE: ${DOCKERIMAGE}"
+echo "RUNNERNAME: ${RUNNERNAME}"
+echo "TAGLIST: ${TAGLIST}"
 echo "MOUNTDOCKERSOCKET: ${MOUNTDOCKERSOCKET}"
 echo "DOCKERNETWORKMODE: ${DOCKERNETWORKMODE}"
-options=()
 
+# Translate some environment variables to command line flags
+options=()
 if [[ -n "${MOUNTDOCKERSOCKET}" ]]; then
     options+=( "--docker-volumes" "${MOUNTDOCKERSOCKET}" )
 fi
@@ -45,11 +52,11 @@ gitlab-runner register \
     --cache-dir=/tmp/cache \
     --url "${GITLABURL}" \
     --registration-token "${RUNNERTOKEN}" \
-    --executor "${EXECUTOR:-docker}" \
-    --docker-image "${DOCKERIMAGE:-alpine:latest}" \
+    --executor "${EXECUTOR}" \
+    --docker-image "${DOCKERIMAGE}" \
     "${options[@]}" \
-    --description "${RUNNERNAME:-gitlab runner}" \
-    --tag-list "${TAGLIST:-docker,auto}" \
+    --description "${RUNNERNAME}" \
+    --tag-list "${TAGLIST}" \
     --run-untagged="true" \
     --locked="false" \
     --access-level="not_protected"

--- a/register_and_run.sh
+++ b/register_and_run.sh
@@ -37,7 +37,7 @@ if [[ -n "${SSHPORT}" ]]; then
     options+=( "--ssh-port" "${SSHPORT}" )
 fi
 
-if [[ -n "${CLONE}_URL" ]]; then
+if [[ -n "${CLONE_URL}" ]]; then
     options+=( "--clone-url" "${CLONE_URL}" )
 fi
 

--- a/register_and_run.sh
+++ b/register_and_run.sh
@@ -7,29 +7,31 @@ echo "DOCKERIMAGE: ${DOCKERIMAGE:-alpine:latest}"
 echo "RUNNERNAME: ${RUNNERNAME:-gitlab runner}"
 echo "TAGLIST: ${TAGLIST:-docker,auto}"
 echo "MOUNTDOCKERSOCKET: ${MOUNTDOCKERSOCKET}"
-if [[ "${MOUNTDOCKERSOCKET}" != "" ]]; then
-    MOUNTDOCKERSOCKET="--docker-volumes ${MOUNTDOCKERSOCKET}"
-fi
 echo "DOCKERNETWORKMODE: ${DOCKERNETWORKMODE}"
-if [[ "${DOCKERNETWORKMODE}" != "" ]]; then
-    DOCKERNETWORKMODE="--docker-network-mode ${DOCKERNETWORKMODE}"
+options=()
+
+if [[ -n "${MOUNTDOCKERSOCKET}" ]]; then
+    options+=( "--docker-volumes" "${MOUNTDOCKERSOCKET}" )
+fi
+if [[ -n "${DOCKERNETWORKMODE}" ]]; then
+    options+=( "--docker-network-mode" "${DOCKERNETWORKMODE}" )
 fi
 
-if [[ "$SSHUSER" != "" ]]; then
-    SSH="--ssh-user=$SSHUSER $SSH"
+if [[ -n "${SSHUSER}" ]]; then
+    options+=( "--ssh-user" "${SSHUSER}" )
 fi
-if [[ "$SSHKEY" != "" ]]; then
-    SSH="--ssh-identity-file=$SSHKEY $SSH"
+if [[ -n "${SSHKEY}" ]]; then
+    options+=( "--ssh-identity-file" "${SSHKEY}" )
 fi
-if [[ "$SSHHOST" != "" ]]; then
-    SSH="--ssh-host=$SSHHOST $SSH"
+if [[ -n "${SSHHOST}" ]]; then
+    options+=( "--ssh-host" "${SSHHOST}" )
 fi
-if [[ "$SSHPORT" != "" ]]; then
-    SSH="--ssh-port=$SSHPORT $SSH"
+if [[ -n "${SSHPORT}" ]]; then
+    options+=( "--ssh-port" "${SSHPORT}" )
 fi
 
-if [[ "$CLONE_URL" != "" ]]; then
-    CLONE_URL="--clone-url ${CLONE_URL}"
+if [[ -n "${CLONE}_URL" ]]; then
+    options+=( "--clone-url" "${CLONE_URL}" )
 fi
 
 mkdir -p /tmp/builds
@@ -45,10 +47,7 @@ gitlab-runner register \
     --registration-token "${RUNNERTOKEN}" \
     --executor "${EXECUTOR:-docker}" \
     --docker-image "${DOCKERIMAGE:-alpine:latest}" \
-    ${MOUNTDOCKERSOCKET} \
-    ${DOCKERNETWORKMODE} \
-    ${SSH} \
-    ${CLONE_URL} \
+    "${options[@]}" \
     --description "${RUNNERNAME:-gitlab runner}" \
     --tag-list "${TAGLIST:-docker,auto}" \
     --run-untagged="true" \

--- a/register_and_run.sh
+++ b/register_and_run.sh
@@ -56,6 +56,7 @@ gitlab-runner register \
     --non-interactive \
     --builds-dir "${BUILDS_DIR}" \
     --cache-dir "${CACHE_DIR}" \
+    --docker-volumes "${CACHE_DIR}" \
     --url "${GITLABURL}" \
     --registration-token "${RUNNERTOKEN}" \
     --executor "${EXECUTOR}" \

--- a/register_and_run.sh
+++ b/register_and_run.sh
@@ -41,15 +41,15 @@ if [[ -n "${CLONE}_URL" ]]; then
     options+=( "--clone-url" "${CLONE_URL}" )
 fi
 
-mkdir -p /tmp/builds
-chmod 777 /tmp/builds
-mkdir -p /tmp/cache
-chmod 777 /tmp/cache
+BUILDS_DIR="/tmp/builds"
+CACHE_DIR="/tmp/cache"
+
+mkdir -p -m 777 "${BUILDS_DIR}" "${CACHE_DIR}"
 
 gitlab-runner register \
     --non-interactive \
-    --builds-dir=/tmp/builds \
-    --cache-dir=/tmp/cache \
+    --builds-dir "${BUILDS_DIR}" \
+    --cache-dir "${CACHE_DIR}" \
     --url "${GITLABURL}" \
     --registration-token "${RUNNERTOKEN}" \
     --executor "${EXECUTOR}" \


### PR DESCRIPTION
The `cache_dir` (`/tmp/cache`) needs to be added as a --docker-volumes flag also, in order for the cache to be enabled and functional. This PR adds this line to enable the cache for all runners.

Volume caches are occasionally pruned, so this should not cause excessive disk usage over time. Existing CI runs will not change in behavior unless they have enabled caching in their `.gitlab-ci.yaml` pipeline config.

I also made the `register_and_run.sh` script more robust while I was in the area.